### PR TITLE
Finished support for foreign keys for postgres

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -186,6 +186,11 @@ var PgDriver = Base.extend({
       this.runSql(sql, callback);
     },
 
+    removeForeignKey: function(tableName, keyName, callback) {
+      var sql = util.format('ALTER TABLE "%s" DROP CONSTRAINT "%s"', tableName, keyName);
+      this.runSql(sql, callback);
+    },
+
     insert: function(tableName, columnNameArray, valueArray, callback) {
       columnNameArray = columnNameArray.map(function(columnName) {
         return (columnName.charAt(0) != '"') ? '"' + columnName + '"' : columnName;

--- a/test/driver/pg_test.js
+++ b/test/driver/pg_test.js
@@ -354,7 +354,7 @@ driver.connect({ driver: 'pg', database: 'db_migrate_test' }, function(err, db) 
       }
     }
   }).addBatch({
-    'addFK': {
+    'addForeignKey': {
       topic: function() {
         db.createTable('Event', {
           id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true },
@@ -375,34 +375,109 @@ driver.connect({ driver: 'pg', database: 'db_migrate_test' }, function(err, db) 
           }.bind(this));
         }.bind(this));
       },
+
       'sets usage and constraints': {
         topic: function() {
-          dbmeta('pg', { connection:db.connection}, function (err, meta) {
-            if (err) {
-              return this.callback(err);
-            }
-
-            meta.getColumns('event', this.callback);
-          }.bind(this));
+          var metaQuery = ['SELECT',
+              ' tc.table_schema, tc.table_name as ortn, kcu.column_name orcn, ccu.table_name,',
+              '  ccu.column_name,',
+              '  cstr.update_rule,',
+              '  cstr.delete_rule',
+              'FROM',
+              '  information_schema.table_constraints AS tc',
+              'JOIN information_schema.key_column_usage AS kcu',
+              '  ON tc.constraint_name = kcu.constraint_name',
+              'JOIN information_schema.constraint_column_usage AS ccu',
+              '  ON ccu.constraint_name = tc.constraint_name',
+              'JOIN information_schema.referential_constraints AS cstr',
+              '  ON cstr.constraint_schema = tc.table_schema',
+              '    AND cstr.constraint_name = tc.constraint_name',
+              'WHERE',
+              '  tc.table_schema = ?',
+              '  AND tc.table_name = ?',
+              '  AND kcu.column_name = ?'].join('\n');
+            db.runSql(metaQuery, ['public', 'event', 'event_id'], this.callback);
         },
 
-        'with correct reference': function(err, columns) {
-          assert.isNotNull(columns);
-          assert.equal(columns.length, 3);
-          var found = 0;
-          for(var i = 0; i < columns.length; i++) {
-            if(columns[i].getName() === 'event_id') {
-              assert.equal(columns[i].isForeignKey(), true);
-              found++;
-            }
-          }
-          assert.equal(found, 1);
+        'with correct references': function(err, result) {
+          var rows = result.rows;
+          assert.isNotNull(rows);
+          assert.equal(rows.length, 1);
+          var row = rows[0];
+          assert.equal(row.table_name, 'eventtype');
+          assert.equal(row.column_name, 'id');
+        },
+
+        'and correct rules': function(err, result) {
+          var rows = result.rows;
+          assert.isNotNull(rows);
+          assert.equal(rows.length, 1);
+          var row = rows[0];
+          assert.equal(row.update_rule, 'NO ACTION');
+          assert.equal(row.delete_rule, 'CASCADE');
         }
       },
 
       teardown: function() {
         db.dropTable('event');
         db.dropTable('eventtype', this.callback);
+      }
+    }
+  }).addBatch({
+    'removeForeignKey': {
+      topic: function() {
+        db.createTable('Event', {
+          id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true },
+          event_id: { type: dataType.INTEGER, notNull: true },
+          title: { type: dataType.STRING }
+        }, function() {
+          db.createTable('EventType', {
+            id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true },
+            title: { type: dataType.STRING }
+          }, function () {
+            db.addForeignKey('event', 'eventtype', 'fk_Event_EventType', {
+              'event_id': 'id'
+            }, {
+              onDelete: 'CASCADE'
+            }, function () {
+              db.removeForeignKey('event', 'fk_Event_EventType', this.callback.bind(this, null));
+            }.bind(this));
+          }.bind(this));
+        }.bind(this));
+      },
+
+      teardown: function() {
+        db.dropTable('Event');
+        db.dropTable('EventType', this.callback);
+      },
+
+      'removes usage and constraints': {
+        topic: function() {
+          var metaQuery = ['SELECT',
+              ' tc.table_schema, tc.table_name as ortn, kcu.column_name orcn, ccu.table_name,',
+              '  ccu.column_name,',
+              '  cstr.update_rule,',
+              '  cstr.delete_rule',
+              'FROM',
+              '  information_schema.table_constraints AS tc',
+              'JOIN information_schema.key_column_usage AS kcu',
+              '  ON tc.constraint_name = kcu.constraint_name',
+              'JOIN information_schema.constraint_column_usage AS ccu',
+              '  ON ccu.constraint_name = tc.constraint_name',
+              'JOIN information_schema.referential_constraints AS cstr',
+              '  ON cstr.constraint_schema = tc.table_schema',
+              '    AND cstr.constraint_name = tc.constraint_name',
+              'WHERE',
+              '  tc.table_schema = ?',
+              '  AND tc.table_name = ?',
+              '  AND kcu.column_name = ?'].join('\n');
+            db.runSql(metaQuery, ['public', 'event', 'event_id'], this.callback);
+        },
+
+        'completely': function(err, result) {
+          assert.isNotNull(result.rows);
+          assert.equal(result.rows.length, 0);
+        }
       }
     }
   }).addBatch({


### PR DESCRIPTION
Added missing `removeForeignKey` function; fixed and completed tests that were failing.
Ideally this is intended to be included in https://github.com/kunklejr/node-db-migrate/pull/181 pull request.
